### PR TITLE
"Next" button was not visible in ncurses

### DIFF
--- a/package/yast2-support.changes
+++ b/package/yast2-support.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Aug 30 13:01:32 UTC 2018 - mvidner@suse.com
+
+- In ncurses the "Next" button to submit the gathered information
+  was not visible (bsc#1093358)
+- Made the Contact Information screen fit in a 80x24 terminal
+- 3.1.8
+
+-------------------------------------------------------------------
 Fri Jun 16 08:08:10 UTC 2017 - jreidinger@suse.com
 
 - Allow service request number longer then 11 digits (bsc#1040706)

--- a/package/yast2-support.spec
+++ b/package/yast2-support.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-support
-Version:        3.1.7
+Version:        3.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/support/dialogs.rb
+++ b/src/include/support/dialogs.rb
@@ -867,7 +867,7 @@ module Yast
 
     def GenerateDialog
       caption = _("Collecting Data")
-      contents = VBox(LogView(Id(:log), _("Progress"), 1000, 1000))
+      contents = VBox(LogView(Id(:log), Opt(:vstretch), _("Progress"), 10, 1000))
       Wizard.SetContentsButtons(
         caption,
         contents,

--- a/src/include/support/dialogs.rb
+++ b/src/include/support/dialogs.rb
@@ -826,7 +826,10 @@ module Yast
 
     def GenerateDialog
       caption = _("Collecting Data")
-      contents = VBox(LogView(Id(:log), Opt(:vstretch), _("Progress"), 10, 1000))
+      contents = VBox(
+        ReplacePoint(Id(:rp), Empty()),
+        LogView(Id(:log), Opt(:vstretch), _("Progress"), 10, 1000)
+      )
       Wizard.SetContentsButtons(
         caption,
         contents,
@@ -875,6 +878,7 @@ module Yast
           end
         else
           Wizard.EnableNextButton
+          UI.ReplaceWidget(Id(:rp), Empty()) # work around bsc#1106744
           break
         end
         ret = Convert.to_symbol(UI.PollInput)

--- a/src/include/support/dialogs.rb
+++ b/src/include/support/dialogs.rb
@@ -677,6 +677,15 @@ module Yast
       Convert.to_symbol(ret)
     end
 
+    # A helper to construct the UI
+    # @param id [Symbol]
+    # @param label [String]
+    # @param key [String] key in Support.options
+    def input_field(id, label, key)
+      value = Support.options.fetch(key, "")
+      Left(InputField(Id(id), label, value))
+    end
+
     # Configure2 dialog
     # @return dialog result
     def ContactDialog
@@ -688,67 +697,13 @@ module Yast
         Frame(
           _("Contact Information"),
           VBox(
-            Left(
-              InputField(
-                Id(:company),
-                _("Company"),
-                Ops.get_string(
-                  Support.options,
-                  "VAR_OPTION_CONTACT_COMPANY",
-                  ""
-                )
-              )
-            ),
-            Left(
-              InputField(
-                Id(:email),
-                _("Email Address"),
-                Ops.get_string(Support.options, "VAR_OPTION_CONTACT_EMAIL", "")
-              )
-            ),
-            Left(
-              InputField(
-                Id(:name),
-                _("Name"),
-                Ops.get_string(Support.options, "VAR_OPTION_CONTACT_NAME", "")
-              )
-            ),
-            Left(
-              InputField(
-                Id(:phone),
-                _("Phone Number"),
-                Ops.get_string(Support.options, "VAR_OPTION_CONTACT_PHONE", "")
-              )
-            ),
-            Left(
-              InputField(
-                Id(:storeid),
-                _("Store ID"),
-                Ops.get_string(
-                  Support.options,
-                  "VAR_OPTION_CONTACT_STOREID",
-                  ""
-                )
-              )
-            ),
-            Left(
-              InputField(
-                Id(:terminalid),
-                _("Terminal ID"),
-                Ops.get_string(
-                  Support.options,
-                  "VAR_OPTION_CONTACT_TERMINALID",
-                  ""
-                )
-              )
-            ),
-            Left(
-              InputField(
-                Id(:gpg_uid),
-                _("GPG UID"),
-                Ops.get_string(Support.options, "VAR_OPTION_GPG_UID", "")
-              )
-            )
+            input_field(:company, _("Company"), "VAR_OPTION_CONTACT_COMPANY"),
+            input_field(:email, _("Email Address"), "VAR_OPTION_CONTACT_EMAIL"),
+            input_field(:name, _("Name"), "VAR_OPTION_CONTACT_NAME"),
+            input_field(:phone, _("Phone Number"), "VAR_OPTION_CONTACT_PHONE"),
+            input_field(:storeid, _("Store ID"), "VAR_OPTION_CONTACT_STOREID"),
+            input_field(:terminalid, _("Terminal ID"), "VAR_OPTION_CONTACT_TERMINALID"),
+            input_field(:gpg_uid, _("GPG UID"), "VAR_OPTION_GPG_UID")
           )
         ),
         Frame(
@@ -759,11 +714,7 @@ module Yast
                 Id(:target),
                 _("Upload Target"),
                 Builtins.deletechars(
-                  Ops.get_string(
-                    Support.options,
-                    "VAR_OPTION_UPLOAD_TARGET",
-                    ""
-                  ),
+                  Support.options.fetch("VAR_OPTION_UPLOAD_TARGET", ""),
                   "'"
                 )
               )

--- a/src/include/support/dialogs.rb
+++ b/src/include/support/dialogs.rb
@@ -696,14 +696,22 @@ module Yast
       contents = VBox(
         Frame(
           _("Contact Information"),
-          VBox(
-            input_field(:company, _("Company"), "VAR_OPTION_CONTACT_COMPANY"),
-            input_field(:email, _("Email Address"), "VAR_OPTION_CONTACT_EMAIL"),
-            input_field(:name, _("Name"), "VAR_OPTION_CONTACT_NAME"),
-            input_field(:phone, _("Phone Number"), "VAR_OPTION_CONTACT_PHONE"),
-            input_field(:storeid, _("Store ID"), "VAR_OPTION_CONTACT_STOREID"),
-            input_field(:terminalid, _("Terminal ID"), "VAR_OPTION_CONTACT_TERMINALID"),
-            input_field(:gpg_uid, _("GPG UID"), "VAR_OPTION_GPG_UID")
+          HBox(
+            Top(
+              VBox(
+                input_field(:company, _("Company"), "VAR_OPTION_CONTACT_COMPANY"),
+                input_field(:email, _("Email Address"), "VAR_OPTION_CONTACT_EMAIL"),
+                input_field(:name, _("Name"), "VAR_OPTION_CONTACT_NAME"),
+                input_field(:phone, _("Phone Number"), "VAR_OPTION_CONTACT_PHONE")
+              )
+            ),
+            Top(
+              VBox(
+                input_field(:storeid, _("Store ID"), "VAR_OPTION_CONTACT_STOREID"),
+                input_field(:terminalid, _("Terminal ID"), "VAR_OPTION_CONTACT_TERMINALID"),
+                input_field(:gpg_uid, _("GPG UID"), "VAR_OPTION_GPG_UID")
+              )
+            )
           )
         ),
         Frame(


### PR DESCRIPTION
[bsc#1093358](https://bugzilla.suse.com/show_bug.cgi?id=1093358)

As reported, after `supportconfig` has gathered the information, it was not possible to press `Next` to submit it. This was regardless of the terminal size (unless you had a terminal 1000 lines tall).

Before:
 ![support-next-bad](https://user-images.githubusercontent.com/102056/44857233-a1c21a80-ac6f-11e8-9a8d-ac6837971d41.png) 
After:
 ![support-next-good](https://user-images.githubusercontent.com/102056/44857243-a555a180-ac6f-11e8-89c0-18d88cf009e4.png)

While testing the fix I've noticed that the preceding dialog suffers from a similar problem, in an xterm with the default size of 80x24:

Before:
 ![support-contact-bad](https://user-images.githubusercontent.com/102056/44857390-03828480-ac70-11e8-9dcd-7e67b191da66.png)
After:
 ![support-contact-good](https://user-images.githubusercontent.com/102056/44857404-08dfcf00-ac70-11e8-9628-9f80e5002490.png)

