### PR TITLE
Fix support url

### DIFF
--- a/package/yast2-support.changes
+++ b/package/yast2-support.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 28 11:57:09 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Fix the support url (bsc#1136145)
+- 4.1.1
+
+-------------------------------------------------------------------
 Thu Dec 13 13:08:25 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-support.spec
+++ b/package/yast2-support.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-support
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/support/dialogs.rb
+++ b/src/include/support/dialogs.rb
@@ -154,7 +154,7 @@ module Yast
           if Support.browser == nil
             Popup.Error(_("Could not find any installed browser."))
           else
-            url = "'http://scc.suse.com/tickets'"
+            url = "http://scc.suse.com/tickets"
             if ENV["LOGNAME"] == "root"
               if Popup.ContinueCancel(
                   Builtins.sformat(


### PR DESCRIPTION
The quotes are no longer necessary after the hardening performed at https://github.com/yast/yast-support/commit/faf0e57fc7675b671721069e64e3ffabaff5b019.

---

Related to 
  * https://bugzilla.suse.com/show_bug.cgi?id=1136145
  * #33 