### PR TITLE
Update desktop file build requirement

### DIFF
--- a/package/yast2-support.changes
+++ b/package/yast2-support.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:41:22 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:41:01 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-support.spec
+++ b/package/yast2-support.spec
@@ -29,6 +29,7 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(yast-rake)
+BuildRequires:  update-desktop-files
 
 BuildArch:      noarch
 

--- a/package/yast2-support.spec
+++ b/package/yast2-support.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-support
 Summary:        YaST2 - Support Inquiries
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-support
 Group:          System/YaST


### PR DESCRIPTION
> - The recent fix in YaST RPM macros now updates the desktop files
> - The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
> - Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`

---

Originally fixed by @lslezak in https://github.com/yast/yast-instserver/pull/45